### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,11 +10,11 @@ Description: Implements multiple imputation of missing covariates by
     multiple imputation approach, and allows imputation of missing
     covariate values from models which are compatible with the user
     specified substantive model.
-Depends: R (>= 3.1.2)
+Depends: R (>= 3.1.2),
+    VGAM
 License: GPL-3
 LazyData: true
-Imports: VGAM,
-    MASS,
+Imports: MASS,
     survival
 Suggests: knitr,
     mitools


### PR DESCRIPTION
When the method is either `podds` or `mlogit` then `VGAM` is used for modeling. However, if the `VGAM` package is not loaded then the `coef` or `coefficient` functions used to extract the estimated coefficients fail since the base S3 versions are used instead of the S4 versions needed to extract the coefficients from `VGAM`.

Alternatively the proper coefficients can be referenced directly in the `smcfcs` function, but I prefer updating the DESCRIPTION file
