### PR TITLE
Fix bug with `coxph`/`compet` where `imputations` not found

### DIFF
--- a/R/smcfcs.r
+++ b/R/smcfcs.r
@@ -739,7 +739,7 @@ smcfcs.core <- function(originaldata, smtype, smformula, method, predictorMatrix
           }
         } else if (smtype == "coxph") {
           ymod <- survival::coxph(as.formula(smformula), imputations[[imp]],
-            control = survival::coxph.control(timefix = FALSE)
+            control = survival::coxph.control(timefix = FALSE), model = TRUE
           )
           outcomeModBeta <- modPostDraw(ymod)
           ymod$coefficients <- outcomeModBeta
@@ -800,7 +800,7 @@ smcfcs.core <- function(originaldata, smtype, smformula, method, predictorMatrix
         } else if (smtype == "compet") {
           for (cause in 1:numCauses) {
             ymod <- survival::coxph(as.formula(smformula[[cause]]), imputations[[imp]],
-              control = survival::coxph.control(timefix = FALSE)
+              control = survival::coxph.control(timefix = FALSE), model = TRUE
             )
             outcomeModBeta[[cause]] <- modPostDraw(ymod)
             ymod$coefficients <- outcomeModBeta[[cause]]


### PR DESCRIPTION
I was having a (known) issue with imputing for a Cox model, where I would get the error:

```
Error in eval(temp, environment(formula$terms), parent.frame()) :
  object 'imputations' not found
```

I traced the issue back to the `basehaz` call in line 746 of [`smcfcs.r`](https://github.com/jwb133/smcfcs/blob/master/R/smcfcs.r). It seems that the function is trying to find the existing imputed data within `ymod`, but this isn't present because the `coxph` call that created it doesn't include `model = TRUE` which includes the model frame in the output.

Adding `model = TRUE` to the `coxph` call fixes the issue for me, and I also added it in the `compet` case where the code is analogous.
